### PR TITLE
Bumped Jackson dependency to latest version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,8 @@
     <opensaml.version>3.4.0</opensaml.version>
     <shibboleth.java-support.version>7.4.0</shibboleth.java-support.version>
     <opensaml-ext.version>1.2.0-SNAPSHOT</opensaml-ext.version>
-    <spring.version>4.3.19.RELEASE</spring.version>
-    
-    <!-- <jackson.version>2.9.4</jackson.version> -->
-    <!-- We have to step down to comply with the version Shibboleth is using. Will be fixed soon. -->
-    <jackson.version>2.8.3</jackson.version>
+    <spring.version>4.3.19.RELEASE</spring.version>    
+    <jackson.version>2.9.7</jackson.version>
     
     <nimbus.version>4.23</nimbus.version>
 


### PR DESCRIPTION
The 2.8.3 that is used by Shibboleth has reported vulnerabilities.